### PR TITLE
Extend DOM history with input text

### DIFF
--- a/browser_use/agent/tests.py
+++ b/browser_use/agent/tests.py
@@ -1,196 +1,267 @@
 import pytest
 
 from browser_use.agent.views import (
-	ActionResult,
-	AgentBrain,
-	AgentHistory,
-	AgentHistoryList,
-	AgentOutput,
+    ActionResult,
+    AgentBrain,
+    AgentHistory,
+    AgentHistoryList,
+    AgentOutput,
 )
 from browser_use.browser.views import BrowserState, BrowserStateHistory, TabInfo
 from browser_use.controller.registry.service import Registry
-from browser_use.controller.views import ClickElementAction, DoneAction, ExtractPageContentAction
+from browser_use.controller.views import (
+        ClickElementAction,
+        DoneAction,
+        ExtractPageContentAction,
+        InputTextAction,
+)
 from browser_use.dom.views import DOMElementNode
 
 
 @pytest.fixture
 def sample_browser_state():
-	return BrowserState(
-		url='https://example.com',
-		title='Example Page',
-		tabs=[TabInfo(url='https://example.com', title='Example Page', page_id=1)],
-		screenshot='screenshot1.png',
-		element_tree=DOMElementNode(
-			tag_name='root',
-			is_visible=True,
-			parent=None,
-			xpath='',
-			attributes={},
-			children=[],
-		),
-		selector_map={},
-	)
+    return BrowserState(
+        url='https://example.com',
+        title='Example Page',
+        tabs=[TabInfo(url='https://example.com', title='Example Page', page_id=1)],
+        screenshot='screenshot1.png',
+        element_tree=DOMElementNode(
+            tag_name='root',
+            is_visible=True,
+            parent=None,
+            xpath='',
+            attributes={},
+            children=[],
+        ),
+        selector_map={},
+    )
 
 
 @pytest.fixture
 def action_registry():
-	registry = Registry()
+    registry = Registry()
 
-	# Register the actions we need for testing
-	@registry.action(description='Click an element', param_model=ClickElementAction)
-	def click_element(params: ClickElementAction, browser=None):
-		pass
+    # Register the actions we need for testing
+    @registry.action(description='Click an element', param_model=ClickElementAction)
+    def click_element(params: ClickElementAction, browser=None):
+        pass
 
-	@registry.action(
-		description='Extract page content',
-		param_model=ExtractPageContentAction,
-	)
-	def extract_page_content(params: ExtractPageContentAction, browser=None):
-		pass
+    @registry.action(
+        description='Extract page content',
+        param_model=ExtractPageContentAction,
+    )
+    def extract_page_content(params: ExtractPageContentAction, browser=None):
+        pass
 
-	@registry.action(description='Mark task as done', param_model=DoneAction)
-	def done(params: DoneAction):
-		pass
+    @registry.action(description='Mark task as done', param_model=DoneAction)
+    def done(params: DoneAction):
+        pass
 
-	# Create the dynamic ActionModel with all registered actions
-	return registry.create_action_model()
+    @registry.action(description='Input text', param_model=InputTextAction)
+    def input_text(params: InputTextAction, browser=None):
+        pass
+
+    # Create the dynamic ActionModel with all registered actions
+    return registry.create_action_model()
 
 
 @pytest.fixture
 def sample_history(action_registry):
-	# Create actions with nested params structure
-	click_action = action_registry(click_element={'index': 1})
+    # Create actions with nested params structure
+    click_action = action_registry(click_element={'index': 1})
 
-	extract_action = action_registry(extract_page_content={'value': 'text'})
+    extract_action = action_registry(extract_page_content={'value': 'text'})
 
-	done_action = action_registry(done={'text': 'Task completed'})
+    done_action = action_registry(done={'text': 'Task completed'})
 
-	histories = [
-		AgentHistory(
-			model_output=AgentOutput(
-				current_state=AgentBrain(
-					evaluation_previous_goal='None',
-					memory='Started task',
-					next_goal='Click button',
-				),
-				action=[click_action],
-			),
-			result=[ActionResult(is_done=False)],
-			state=BrowserStateHistory(
-				url='https://example.com',
-				title='Page 1',
-				tabs=[TabInfo(url='https://example.com', title='Page 1', page_id=1)],
-				screenshot='screenshot1.png',
-				interacted_element=[{'xpath': '//button[1]'}],
-			),
-		),
-		AgentHistory(
-			model_output=AgentOutput(
-				current_state=AgentBrain(
-					evaluation_previous_goal='Clicked button',
-					memory='Button clicked',
-					next_goal='Extract content',
-				),
-				action=[extract_action],
-			),
-			result=[
-				ActionResult(
-					is_done=False,
-					extracted_content='Extracted text',
-					error='Failed to extract completely',
-				)
-			],
-			state=BrowserStateHistory(
-				url='https://example.com/page2',
-				title='Page 2',
-				tabs=[TabInfo(url='https://example.com/page2', title='Page 2', page_id=2)],
-				screenshot='screenshot2.png',
-				interacted_element=[{'xpath': '//div[1]'}],
-			),
-		),
-		AgentHistory(
-			model_output=AgentOutput(
-				current_state=AgentBrain(
-					evaluation_previous_goal='Extracted content',
-					memory='Content extracted',
-					next_goal='Finish task',
-				),
-				action=[done_action],
-			),
-			result=[ActionResult(is_done=True, extracted_content='Task completed', error=None)],
-			state=BrowserStateHistory(
-				url='https://example.com/page2',
-				title='Page 2',
-				tabs=[TabInfo(url='https://example.com/page2', title='Page 2', page_id=2)],
-				screenshot='screenshot3.png',
-				interacted_element=[{'xpath': '//div[1]'}],
-			),
-		),
-	]
-	return AgentHistoryList(history=histories)
+    histories = [
+        AgentHistory(
+            model_output=AgentOutput(
+                current_state=AgentBrain(
+                    evaluation_previous_goal='None',
+                    memory='Started task',
+                    next_goal='Click button',
+                ),
+                action=[click_action],
+            ),
+            result=[ActionResult(is_done=False)],
+            state=BrowserStateHistory(
+                url='https://example.com',
+                title='Page 1',
+                tabs=[TabInfo(url='https://example.com', title='Page 1', page_id=1)],
+                screenshot='screenshot1.png',
+                interacted_element=[{'xpath': '//button[1]'}],
+            ),
+        ),
+        AgentHistory(
+            model_output=AgentOutput(
+                current_state=AgentBrain(
+                    evaluation_previous_goal='Clicked button',
+                    memory='Button clicked',
+                    next_goal='Extract content',
+                ),
+                action=[extract_action],
+            ),
+            result=[
+                ActionResult(
+                    is_done=False,
+                    extracted_content='Extracted text',
+                    error='Failed to extract completely',
+                )
+            ],
+            state=BrowserStateHistory(
+                url='https://example.com/page2',
+                title='Page 2',
+                tabs=[TabInfo(url='https://example.com/page2', title='Page 2', page_id=2)],
+                screenshot='screenshot2.png',
+                interacted_element=[{'xpath': '//div[1]'}],
+            ),
+        ),
+        AgentHistory(
+            model_output=AgentOutput(
+                current_state=AgentBrain(
+                    evaluation_previous_goal='Extracted content',
+                    memory='Content extracted',
+                    next_goal='Finish task',
+                ),
+                action=[done_action],
+            ),
+            result=[ActionResult(is_done=True, extracted_content='Task completed', error=None)],
+            state=BrowserStateHistory(
+                url='https://example.com/page2',
+                title='Page 2',
+                tabs=[TabInfo(url='https://example.com/page2', title='Page 2', page_id=2)],
+                screenshot='screenshot3.png',
+                interacted_element=[{'xpath': '//div[1]'}],
+            ),
+        ),
+    ]
+    return AgentHistoryList(history=histories)
 
 
 def test_last_model_output(sample_history: AgentHistoryList):
-	last_output = sample_history.last_action()
-	print(last_output)
-	assert last_output == {'done': {'text': 'Task completed'}}
+    last_output = sample_history.last_action()
+    print(last_output)
+    assert last_output == {'done': {'text': 'Task completed'}}
 
 
 def test_get_errors(sample_history: AgentHistoryList):
-	errors = sample_history.errors()
-	assert len(errors) == 1
-	assert errors[0] == 'Failed to extract completely'
+    errors = sample_history.errors()
+    assert len(errors) == 1
+    assert errors[0] == 'Failed to extract completely'
 
 
 def test_final_result(sample_history: AgentHistoryList):
-	assert sample_history.final_result() == 'Task completed'
+    assert sample_history.final_result() == 'Task completed'
 
 
 def test_is_done(sample_history: AgentHistoryList):
-	assert sample_history.is_done() == True
+    assert sample_history.is_done() == True
 
 
 def test_urls(sample_history: AgentHistoryList):
-	urls = sample_history.urls()
-	assert 'https://example.com' in urls
-	assert 'https://example.com/page2' in urls
+    urls = sample_history.urls()
+    assert 'https://example.com' in urls
+    assert 'https://example.com/page2' in urls
 
 
 def test_all_screenshots(sample_history: AgentHistoryList):
-	screenshots = sample_history.screenshots()
-	assert len(screenshots) == 3
-	assert screenshots == ['screenshot1.png', 'screenshot2.png', 'screenshot3.png']
+    screenshots = sample_history.screenshots()
+    assert len(screenshots) == 3
+    assert screenshots == ['screenshot1.png', 'screenshot2.png', 'screenshot3.png']
 
 
 def test_all_model_outputs(sample_history: AgentHistoryList):
-	outputs = sample_history.model_actions()
-	print(f'DEBUG: {outputs[0]}')
-	assert len(outputs) == 3
-	# get first key value pair
-	assert dict([next(iter(outputs[0].items()))]) == {'click_element': {'index': 1}}
-	assert dict([next(iter(outputs[1].items()))]) == {'extract_page_content': {'value': 'text'}}
-	assert dict([next(iter(outputs[2].items()))]) == {'done': {'text': 'Task completed'}}
+    outputs = sample_history.model_actions()
+    print(f'DEBUG: {outputs[0]}')
+    assert len(outputs) == 3
+    # get first key value pair
+    assert dict([next(iter(outputs[0].items()))]) == {'click_element': {'index': 1}}
+    assert dict([next(iter(outputs[1].items()))]) == {'extract_page_content': {'value': 'text'}}
+    assert dict([next(iter(outputs[2].items()))]) == {'done': {'text': 'Task completed'}}
 
 
 def test_all_model_outputs_filtered(sample_history: AgentHistoryList):
-	filtered = sample_history.model_actions_filtered(include=['click_element'])
-	assert len(filtered) == 1
-	assert filtered[0]['click_element']['index'] == 1
+    filtered = sample_history.model_actions_filtered(include=['click_element'])
+    assert len(filtered) == 1
+    assert filtered[0]['click_element']['index'] == 1
 
 
 def test_empty_history():
-	empty_history = AgentHistoryList(history=[])
-	assert empty_history.last_action() is None
-	assert empty_history.final_result() is None
-	assert empty_history.is_done() == False
-	assert len(empty_history.urls()) == 0
+    empty_history = AgentHistoryList(history=[])
+    assert empty_history.last_action() is None
+    assert empty_history.final_result() is None
+    assert empty_history.is_done() == False
+    assert len(empty_history.urls()) == 0
 
 
 # Add a test to verify action creation
 def test_action_creation(action_registry):
-	click_action = action_registry(click_element={'index': 1})
+        click_action = action_registry(click_element={'index': 1})
 
-	assert click_action.model_dump(exclude_none=True) == {'click_element': {'index': 1}}
+        assert click_action.model_dump(exclude_none=True) == {'click_element': {'index': 1}}
+
+
+@pytest.fixture
+def input_text_history(action_registry):
+        input_action = action_registry(input_text={'index': 1, 'text': 'hello'})
+        history_item = AgentHistory(
+                model_output=AgentOutput(
+                        current_state=AgentBrain(
+                                evaluation_previous_goal='None',
+                                memory='Started task',
+                                next_goal='Input text',
+                        ),
+                        action=[input_action],
+                ),
+                result=[ActionResult(is_done=False)],
+                state=BrowserStateHistory(
+                        url='https://example.com',
+                        title='Page 1',
+                        tabs=[TabInfo(url='https://example.com', title='Page 1', page_id=1)],
+                        screenshot=None,
+                        interacted_element=[
+                                DOMHistoryElement(
+                                        tag_name='input',
+                                        xpath='//input[1]',
+                                        highlight_index=1,
+                                        entire_parent_branch_path=[],
+                                        attributes={'type': 'text'},
+                                        input_text='hello',
+                                )
+                        ],
+                ),
+        )
+        return AgentHistoryList(history=[history_item])
+
+
+def test_model_actions_include_input_text(input_text_history: AgentHistoryList):
+        actions = input_text_history.model_actions()
+        assert actions[0]['interacted_element']['input_text'] == 'hello'
+
+
+def test_get_interacted_element_input_text(action_registry):
+        input_action = action_registry(input_text={'index': 1, 'text': 'typed'})
+        model_output = AgentOutput(
+                current_state=AgentBrain(
+                        evaluation_previous_goal='',
+                        memory='',
+                        next_goal='',
+                ),
+                action=[input_action],
+        )
+        dom_el = DOMElementNode(
+                tag_name='input',
+                xpath='//input',
+                attributes={},
+                children=[],
+                is_visible=True,
+                parent=None,
+                highlight_index=1,
+        )
+        selector_map = {1: dom_el}
+        elements = AgentHistory.get_interacted_element(model_output, selector_map)
+        assert elements[0].input_text == 'typed'
 
 
 # run this with:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -15,9 +15,9 @@ from browser_use.agent.message_manager.views import MessageManagerState
 from browser_use.browser.views import BrowserStateHistory
 from browser_use.controller.registry.views import ActionModel
 from browser_use.dom.history_tree_processor.service import (
-	DOMElementNode,
-	DOMHistoryElement,
-	HistoryTreeProcessor,
+    DOMElementNode,
+    DOMHistoryElement,
+    HistoryTreeProcessor,
 )
 from browser_use.dom.views import SelectorMap
 
@@ -25,380 +25,386 @@ ToolCallingMethod = Literal['function_calling', 'json_mode', 'raw', 'auto']
 
 
 class AgentSettings(BaseModel):
-	"""Options for the agent"""
+    """Options for the agent"""
 
-	use_vision: bool = True
-	use_vision_for_planner: bool = False
-	save_conversation_path: Optional[str] = None
-	save_conversation_path_encoding: Optional[str] = 'utf-8'
-	max_failures: int = 3
-	retry_delay: int = 10
-	max_input_tokens: int = 128000
-	validate_output: bool = False
-	message_context: Optional[str] = None
-	generate_gif: bool | str = False
-	available_file_paths: Optional[list[str]] = None
-	override_system_message: Optional[str] = None
-	extend_system_message: Optional[str] = None
-	include_attributes: list[str] = [
-		'title',
-		'type',
-		'name',
-		'role',
-		'tabindex',
-		'aria-label',
-		'placeholder',
-		'value',
-		'alt',
-		'aria-expanded',
-	]
-	max_actions_per_step: int = 10
+    use_vision: bool = True
+    use_vision_for_planner: bool = False
+    save_conversation_path: Optional[str] = None
+    save_conversation_path_encoding: Optional[str] = 'utf-8'
+    max_failures: int = 3
+    retry_delay: int = 10
+    max_input_tokens: int = 128000
+    validate_output: bool = False
+    message_context: Optional[str] = None
+    generate_gif: bool | str = False
+    available_file_paths: Optional[list[str]] = None
+    override_system_message: Optional[str] = None
+    extend_system_message: Optional[str] = None
+    include_attributes: list[str] = [
+        'title',
+        'type',
+        'name',
+        'role',
+        'tabindex',
+        'aria-label',
+        'placeholder',
+        'value',
+        'alt',
+        'aria-expanded',
+    ]
+    max_actions_per_step: int = 10
 
-	tool_calling_method: Optional[ToolCallingMethod] = 'auto'
-	page_extraction_llm: Optional[BaseChatModel] = None
-	planner_llm: Optional[BaseChatModel] = None
-	planner_interval: int = 1  # Run planner every N steps
+    tool_calling_method: Optional[ToolCallingMethod] = 'auto'
+    page_extraction_llm: Optional[BaseChatModel] = None
+    planner_llm: Optional[BaseChatModel] = None
+    planner_interval: int = 1  # Run planner every N steps
 
 
 class AgentState(BaseModel):
-	"""Holds all state information for an Agent"""
+    """Holds all state information for an Agent"""
 
-	agent_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-	n_steps: int = 1
-	consecutive_failures: int = 0
-	last_result: Optional[List['ActionResult']] = None
-	history: AgentHistoryList = Field(default_factory=lambda: AgentHistoryList(history=[]))
-	last_plan: Optional[str] = None
-	paused: bool = False
-	stopped: bool = False
+    agent_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    n_steps: int = 1
+    consecutive_failures: int = 0
+    last_result: Optional[List['ActionResult']] = None
+    history: AgentHistoryList = Field(default_factory=lambda: AgentHistoryList(history=[]))
+    last_plan: Optional[str] = None
+    paused: bool = False
+    stopped: bool = False
 
-	message_manager_state: MessageManagerState = Field(default_factory=MessageManagerState)
+    message_manager_state: MessageManagerState = Field(default_factory=MessageManagerState)
 
-	# class Config:
-	# 	arbitrary_types_allowed = True
+    # class Config:
+    #     arbitrary_types_allowed = True
 
 
 @dataclass
 class AgentStepInfo:
-	step_number: int
-	max_steps: int
+    step_number: int
+    max_steps: int
 
-	def is_last_step(self) -> bool:
-		"""Check if this is the last step"""
-		return self.step_number >= self.max_steps - 1
+    def is_last_step(self) -> bool:
+        """Check if this is the last step"""
+        return self.step_number >= self.max_steps - 1
 
 
 class ActionResult(BaseModel):
-	"""Result of executing an action"""
+    """Result of executing an action"""
 
-	is_done: Optional[bool] = False
-	success: Optional[bool] = None
-	extracted_content: Optional[str] = None
-	error: Optional[str] = None
-	include_in_memory: bool = False  # whether to include in past messages as context or not
+    is_done: Optional[bool] = False
+    success: Optional[bool] = None
+    extracted_content: Optional[str] = None
+    error: Optional[str] = None
+    include_in_memory: bool = False  # whether to include in past messages as context or not
 
 
 class StepMetadata(BaseModel):
-	"""Metadata for a single step including timing and token information"""
+    """Metadata for a single step including timing and token information"""
 
-	step_start_time: float
-	step_end_time: float
-	input_tokens: int  # Approximate tokens from message manager for this step
-	output_tokens: Optional[int] = 0 
-	step_number: int
+    step_start_time: float
+    step_end_time: float
+    input_tokens: int  # Approximate tokens from message manager for this step
+    output_tokens: Optional[int] = 0 
+    step_number: int
 
-	@property
-	def duration_seconds(self) -> float:
-		"""Calculate step duration in seconds"""
-		return self.step_end_time - self.step_start_time
+    @property
+    def duration_seconds(self) -> float:
+        """Calculate step duration in seconds"""
+        return self.step_end_time - self.step_start_time
 
 
 class AgentBrain(BaseModel):
-	"""Current state of the agent"""
+    """Current state of the agent"""
 
-	evaluation_previous_goal: str
-	memory: str
-	next_goal: str
+    evaluation_previous_goal: str
+    memory: str
+    next_goal: str
 
 
 class AgentOutput(BaseModel):
-	"""Output model for agent
+    """Output model for agent
 
-	@dev note: this model is extended with custom actions in AgentService. You can also use some fields that are not in this model as provided by the linter, as long as they are registered in the DynamicActions model.
-	"""
+    @dev note: this model is extended with custom actions in AgentService. You can also use some fields that are not in this model as provided by the linter, as long as they are registered in the DynamicActions model.
+    """
 
-	model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
-	current_state: AgentBrain
-	action: list[ActionModel] = Field(
-		...,
-		description='List of actions to execute',
-		json_schema_extra={'min_items': 1},  # Ensure at least one action is provided
-	)
+    current_state: AgentBrain
+    action: list[ActionModel] = Field(
+        ...,
+        description='List of actions to execute',
+        json_schema_extra={'min_items': 1},  # Ensure at least one action is provided
+    )
 
-	@staticmethod
-	def type_with_custom_actions(custom_actions: Type[ActionModel]) -> Type['AgentOutput']:
-		"""Extend actions with custom actions"""
-		model_ = create_model(
-			'AgentOutput',
-			__base__=AgentOutput,
-			action=(
-				list[custom_actions],
-				Field(..., description='List of actions to execute', json_schema_extra={'min_items': 1}),
-			),
-			__module__=AgentOutput.__module__,
-		)
-		model_.__doc__ = 'AgentOutput model with custom actions'
-		return model_
+    @staticmethod
+    def type_with_custom_actions(custom_actions: Type[ActionModel]) -> Type['AgentOutput']:
+        """Extend actions with custom actions"""
+        model_ = create_model(
+            'AgentOutput',
+            __base__=AgentOutput,
+            action=(
+                list[custom_actions],
+                Field(..., description='List of actions to execute', json_schema_extra={'min_items': 1}),
+            ),
+            __module__=AgentOutput.__module__,
+        )
+        model_.__doc__ = 'AgentOutput model with custom actions'
+        return model_
 
 
 class AgentHistory(BaseModel):
-	"""History item for agent actions"""
+    """History item for agent actions"""
 
-	model_output: AgentOutput | None
-	result: list[ActionResult]
-	state: BrowserStateHistory
-	metadata: Optional[StepMetadata] = None
+    model_output: AgentOutput | None
+    result: list[ActionResult]
+    state: BrowserStateHistory
+    metadata: Optional[StepMetadata] = None
 
-	model_config = ConfigDict(arbitrary_types_allowed=True, protected_namespaces=())
+    model_config = ConfigDict(arbitrary_types_allowed=True, protected_namespaces=())
 
-	@staticmethod
-	def get_interacted_element(model_output: AgentOutput, selector_map: SelectorMap) -> list[DOMHistoryElement | None]:
-		elements = []
-		for action in model_output.action:
-			index = action.get_index()
-			if index and index in selector_map:
-				el: DOMElementNode = selector_map[index]
-				elements.append(HistoryTreeProcessor.convert_dom_element_to_history_element(el))
-			else:
-				elements.append(None)
-		return elements
+    @staticmethod
+    def get_interacted_element(model_output: AgentOutput, selector_map: SelectorMap) -> list[DOMHistoryElement | None]:
+        elements = []
+        for action in model_output.action:
+                index = action.get_index()
+                if index and index in selector_map:
+                        el: DOMElementNode = selector_map[index]
+                        input_action = getattr(action, 'input_text', None)
+                        typed_text = input_action.text if input_action else None
+                        elements.append(
+                                HistoryTreeProcessor.convert_dom_element_to_history_element(
+                                        el, input_text=typed_text
+                                )
+                        )
+                else:
+                        elements.append(None)
+        return elements
 
-	def model_dump(self, **kwargs) -> Dict[str, Any]:
-		"""Custom serialization handling circular references"""
+    def model_dump(self, **kwargs) -> Dict[str, Any]:
+        """Custom serialization handling circular references"""
 
-		# Handle action serialization
-		model_output_dump = None
-		if self.model_output:
-			action_dump = [action.model_dump(exclude_none=True) for action in self.model_output.action]
-			model_output_dump = {
-				'current_state': self.model_output.current_state.model_dump(),
-				'action': action_dump,  # This preserves the actual action data
-			}
+        # Handle action serialization
+        model_output_dump = None
+        if self.model_output:
+            action_dump = [action.model_dump(exclude_none=True) for action in self.model_output.action]
+            model_output_dump = {
+                'current_state': self.model_output.current_state.model_dump(),
+                'action': action_dump,  # This preserves the actual action data
+            }
 
-		return {
-			'model_output': model_output_dump,
-			'result': [r.model_dump(exclude_none=True) for r in self.result],
-			'state': self.state.to_dict(),
-			'metadata': self.metadata.model_dump() if self.metadata else None,
-		}
+        return {
+            'model_output': model_output_dump,
+            'result': [r.model_dump(exclude_none=True) for r in self.result],
+            'state': self.state.to_dict(),
+            'metadata': self.metadata.model_dump() if self.metadata else None,
+        }
 
 
 class AgentHistoryList(BaseModel):
-	"""List of agent history items"""
+    """List of agent history items"""
 
-	history: list[AgentHistory]
+    history: list[AgentHistory]
 
-	def total_duration_seconds(self) -> float:
-		"""Get total duration of all steps in seconds"""
-		total = 0.0
-		for h in self.history:
-			if h.metadata:
-				total += h.metadata.duration_seconds
-		return total
+    def total_duration_seconds(self) -> float:
+        """Get total duration of all steps in seconds"""
+        total = 0.0
+        for h in self.history:
+            if h.metadata:
+                total += h.metadata.duration_seconds
+        return total
 
-	def total_input_tokens(self) -> int:
-		"""
-		Get total tokens used across all steps.
-		Note: These are from the approximate token counting of the message manager.
-		For accurate token counting, use tools like LangChain Smith or OpenAI's token counters.
-		"""
-		total = 0
-		for h in self.history:
-			if h.metadata:
-				total += h.metadata.input_tokens
-		return total
-	
-	def total_output_tokens(self) -> int:
-		return sum((item.metadata.output_tokens or 0) for item in self.history if item.metadata)	
+    def total_input_tokens(self) -> int:
+        """
+        Get total tokens used across all steps.
+        Note: These are from the approximate token counting of the message manager.
+        For accurate token counting, use tools like LangChain Smith or OpenAI's token counters.
+        """
+        total = 0
+        for h in self.history:
+            if h.metadata:
+                total += h.metadata.input_tokens
+        return total
+    
+    def total_output_tokens(self) -> int:
+        return sum((item.metadata.output_tokens or 0) for item in self.history if item.metadata)    
 
-	def input_token_usage(self) -> list[int]:
-		"""Get token usage for each step"""
-		return [h.metadata.input_tokens for h in self.history if h.metadata]
+    def input_token_usage(self) -> list[int]:
+        """Get token usage for each step"""
+        return [h.metadata.input_tokens for h in self.history if h.metadata]
 
-	def __str__(self) -> str:
-		"""Representation of the AgentHistoryList object"""
-		return f'AgentHistoryList(all_results={self.action_results()}, all_model_outputs={self.model_actions()})'
+    def __str__(self) -> str:
+        """Representation of the AgentHistoryList object"""
+        return f'AgentHistoryList(all_results={self.action_results()}, all_model_outputs={self.model_actions()})'
 
-	def __repr__(self) -> str:
-		"""Representation of the AgentHistoryList object"""
-		return self.__str__()
+    def __repr__(self) -> str:
+        """Representation of the AgentHistoryList object"""
+        return self.__str__()
 
-	def save_to_file(self, filepath: str | Path) -> None:
-		"""Save history to JSON file with proper serialization"""
-		try:
-			Path(filepath).parent.mkdir(parents=True, exist_ok=True)
-			data = self.model_dump()
-			with open(filepath, 'w', encoding='utf-8') as f:
-				json.dump(data, f, indent=2)
-		except Exception as e:
-			raise e
+    def save_to_file(self, filepath: str | Path) -> None:
+        """Save history to JSON file with proper serialization"""
+        try:
+            Path(filepath).parent.mkdir(parents=True, exist_ok=True)
+            data = self.model_dump()
+            with open(filepath, 'w', encoding='utf-8') as f:
+                json.dump(data, f, indent=2)
+        except Exception as e:
+            raise e
 
-	def model_dump(self, **kwargs) -> Dict[str, Any]:
-		"""Custom serialization that properly uses AgentHistory's model_dump"""
-		return {
-			'history': [h.model_dump(**kwargs) for h in self.history],
-		}
+    def model_dump(self, **kwargs) -> Dict[str, Any]:
+        """Custom serialization that properly uses AgentHistory's model_dump"""
+        return {
+            'history': [h.model_dump(**kwargs) for h in self.history],
+        }
 
-	@classmethod
-	def load_from_file(cls, filepath: str | Path, output_model: Type[AgentOutput]) -> 'AgentHistoryList':
-		"""Load history from JSON file"""
-		with open(filepath, 'r', encoding='utf-8') as f:
-			data = json.load(f)
-		# loop through history and validate output_model actions to enrich with custom actions
-		for h in data['history']:
-			if h['model_output']:
-				if isinstance(h['model_output'], dict):
-					h['model_output'] = output_model.model_validate(h['model_output'])
-				else:
-					h['model_output'] = None
-			if 'interacted_element' not in h['state']:
-				h['state']['interacted_element'] = None
-		history = cls.model_validate(data)
-		return history
+    @classmethod
+    def load_from_file(cls, filepath: str | Path, output_model: Type[AgentOutput]) -> 'AgentHistoryList':
+        """Load history from JSON file"""
+        with open(filepath, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        # loop through history and validate output_model actions to enrich with custom actions
+        for h in data['history']:
+            if h['model_output']:
+                if isinstance(h['model_output'], dict):
+                    h['model_output'] = output_model.model_validate(h['model_output'])
+                else:
+                    h['model_output'] = None
+            if 'interacted_element' not in h['state']:
+                h['state']['interacted_element'] = None
+        history = cls.model_validate(data)
+        return history
 
-	def last_action(self) -> None | dict:
-		"""Last action in history"""
-		if self.history and self.history[-1].model_output:
-			return self.history[-1].model_output.action[-1].model_dump(exclude_none=True)
-		return None
+    def last_action(self) -> None | dict:
+        """Last action in history"""
+        if self.history and self.history[-1].model_output:
+            return self.history[-1].model_output.action[-1].model_dump(exclude_none=True)
+        return None
 
-	def errors(self) -> list[str | None]:
-		"""Get all errors from history, with None for steps without errors"""
-		errors = []
-		for h in self.history:
-			step_errors = [r.error for r in h.result if r.error]
+    def errors(self) -> list[str | None]:
+        """Get all errors from history, with None for steps without errors"""
+        errors = []
+        for h in self.history:
+            step_errors = [r.error for r in h.result if r.error]
 
-			# each step can have only one error
-			errors.append(step_errors[0] if step_errors else None)
-		return errors
+            # each step can have only one error
+            errors.append(step_errors[0] if step_errors else None)
+        return errors
 
-	def final_result(self) -> None | str:
-		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
-			return self.history[-1].result[-1].extracted_content
-		return None
+    def final_result(self) -> None | str:
+        """Final result from history"""
+        if self.history and self.history[-1].result[-1].extracted_content:
+            return self.history[-1].result[-1].extracted_content
+        return None
 
-	def is_done(self) -> bool:
-		"""Check if the agent is done"""
-		if self.history and len(self.history[-1].result) > 0:
-			last_result = self.history[-1].result[-1]
-			return last_result.is_done is True
-		return False
+    def is_done(self) -> bool:
+        """Check if the agent is done"""
+        if self.history and len(self.history[-1].result) > 0:
+            last_result = self.history[-1].result[-1]
+            return last_result.is_done is True
+        return False
 
-	def is_successful(self) -> bool | None:
-		"""Check if the agent completed successfully - the agent decides in the last step if it was successful or not. None if not done yet."""
-		if self.history and len(self.history[-1].result) > 0:
-			last_result = self.history[-1].result[-1]
-			if last_result.is_done is True:
-				return last_result.success
-		return None
+    def is_successful(self) -> bool | None:
+        """Check if the agent completed successfully - the agent decides in the last step if it was successful or not. None if not done yet."""
+        if self.history and len(self.history[-1].result) > 0:
+            last_result = self.history[-1].result[-1]
+            if last_result.is_done is True:
+                return last_result.success
+        return None
 
-	def has_errors(self) -> bool:
-		"""Check if the agent has any non-None errors"""
-		return any(error is not None for error in self.errors())
+    def has_errors(self) -> bool:
+        """Check if the agent has any non-None errors"""
+        return any(error is not None for error in self.errors())
 
-	def urls(self) -> list[str | None]:
-		"""Get all unique URLs from history"""
-		return [h.state.url if h.state.url is not None else None for h in self.history]
+    def urls(self) -> list[str | None]:
+        """Get all unique URLs from history"""
+        return [h.state.url if h.state.url is not None else None for h in self.history]
 
-	def screenshots(self) -> list[str | None]:
-		"""Get all screenshots from history"""
-		return [h.state.screenshot if h.state.screenshot is not None else None for h in self.history]
+    def screenshots(self) -> list[str | None]:
+        """Get all screenshots from history"""
+        return [h.state.screenshot if h.state.screenshot is not None else None for h in self.history]
 
-	def action_names(self) -> list[str]:
-		"""Get all action names from history"""
-		action_names = []
-		for action in self.model_actions():
-			actions = list(action.keys())
-			if actions:
-				action_names.append(actions[0])
-		return action_names
+    def action_names(self) -> list[str]:
+        """Get all action names from history"""
+        action_names = []
+        for action in self.model_actions():
+            actions = list(action.keys())
+            if actions:
+                action_names.append(actions[0])
+        return action_names
 
-	def model_thoughts(self) -> list[AgentBrain]:
-		"""Get all thoughts from history"""
-		return [h.model_output.current_state for h in self.history if h.model_output]
+    def model_thoughts(self) -> list[AgentBrain]:
+        """Get all thoughts from history"""
+        return [h.model_output.current_state for h in self.history if h.model_output]
 
-	def model_outputs(self) -> list[AgentOutput]:
-		"""Get all model outputs from history"""
-		return [h.model_output for h in self.history if h.model_output]
+    def model_outputs(self) -> list[AgentOutput]:
+        """Get all model outputs from history"""
+        return [h.model_output for h in self.history if h.model_output]
 
-	# get all actions with params
-	def model_actions(self) -> list[dict]:
-		"""Get all actions from history"""
-		outputs = []
+    # get all actions with params
+    def model_actions(self) -> list[dict]:
+        """Get all actions from history"""
+        outputs = []
 
-		for h in self.history:
-			if h.model_output:
-				for action, interacted_element in zip(h.model_output.action, h.state.interacted_element):
-					output = action.model_dump(exclude_none=True)
-					output['interacted_element'] = interacted_element
-					outputs.append(output)
-		return outputs
+        for h in self.history:
+            if h.model_output:
+                for action, interacted_element in zip(h.model_output.action, h.state.interacted_element):
+                    output = action.model_dump(exclude_none=True)
+                    output['interacted_element'] = interacted_element
+                    outputs.append(output)
+        return outputs
 
-	def action_results(self) -> list[ActionResult]:
-		"""Get all results from history"""
-		results = []
-		for h in self.history:
-			results.extend([r for r in h.result if r])
-		return results
+    def action_results(self) -> list[ActionResult]:
+        """Get all results from history"""
+        results = []
+        for h in self.history:
+            results.extend([r for r in h.result if r])
+        return results
 
-	def extracted_content(self) -> list[str]:
-		"""Get all extracted content from history"""
-		content = []
-		for h in self.history:
-			content.extend([r.extracted_content for r in h.result if r.extracted_content])
-		return content
+    def extracted_content(self) -> list[str]:
+        """Get all extracted content from history"""
+        content = []
+        for h in self.history:
+            content.extend([r.extracted_content for r in h.result if r.extracted_content])
+        return content
 
-	def model_actions_filtered(self, include: list[str] | None = None) -> list[dict]:
-		"""Get all model actions from history as JSON"""
-		if include is None:
-			include = []
-		outputs = self.model_actions()
-		result = []
-		for o in outputs:
-			for i in include:
-				if i == list(o.keys())[0]:
-					result.append(o)
-		return result
+    def model_actions_filtered(self, include: list[str] | None = None) -> list[dict]:
+        """Get all model actions from history as JSON"""
+        if include is None:
+            include = []
+        outputs = self.model_actions()
+        result = []
+        for o in outputs:
+            for i in include:
+                if i == list(o.keys())[0]:
+                    result.append(o)
+        return result
 
-	def number_of_steps(self) -> int:
-		"""Get the number of steps in the history"""
-		return len(self.history)
+    def number_of_steps(self) -> int:
+        """Get the number of steps in the history"""
+        return len(self.history)
 
-	def get_total_input_tokens(self) -> int:
-		"""Return total input tokens used across all steps"""
-		return self.state.history.total_input_tokens()
+    def get_total_input_tokens(self) -> int:
+        """Return total input tokens used across all steps"""
+        return self.state.history.total_input_tokens()
 
-	def get_total_output_tokens(self) -> int:
-		"""Return total output tokens used across all steps"""
-		return self.state.history.total_output_tokens()
+    def get_total_output_tokens(self) -> int:
+        """Return total output tokens used across all steps"""
+        return self.state.history.total_output_tokens()
 
 class AgentError:
-	"""Container for agent error handling"""
+    """Container for agent error handling"""
 
-	VALIDATION_ERROR = 'Invalid model output format. Please follow the correct schema.'
-	RATE_LIMIT_ERROR = 'Rate limit reached. Waiting before retry.'
-	NO_VALID_ACTION = 'No valid action found'
+    VALIDATION_ERROR = 'Invalid model output format. Please follow the correct schema.'
+    RATE_LIMIT_ERROR = 'Rate limit reached. Waiting before retry.'
+    NO_VALID_ACTION = 'No valid action found'
 
-	@staticmethod
-	def format_error(error: Exception, include_trace: bool = False) -> str:
-		"""Format error message based on error type and optionally include trace"""
-		message = ''
-		if isinstance(error, ValidationError):
-			return f'{AgentError.VALIDATION_ERROR}\nDetails: {str(error)}'
-		if isinstance(error, RateLimitError):
-			return AgentError.RATE_LIMIT_ERROR
-		if include_trace:
-			return f'{str(error)}\nStacktrace:\n{traceback.format_exc()}'
-		return f'{str(error)}'
+    @staticmethod
+    def format_error(error: Exception, include_trace: bool = False) -> str:
+        """Format error message based on error type and optionally include trace"""
+        message = ''
+        if isinstance(error, ValidationError):
+            return f'{AgentError.VALIDATION_ERROR}\nDetails: {str(error)}'
+        if isinstance(error, RateLimitError):
+            return AgentError.RATE_LIMIT_ERROR
+        if include_trace:
+            return f'{str(error)}\nStacktrace:\n{traceback.format_exc()}'
+        return f'{str(error)}'

--- a/browser_use/dom/history_tree_processor/service.py
+++ b/browser_use/dom/history_tree_processor/service.py
@@ -6,102 +6,106 @@ from browser_use.dom.views import DOMElementNode
 
 
 class HistoryTreeProcessor:
-	""" "
-	Operations on the DOM elements
+    """ "
+    Operations on the DOM elements
 
-	@dev be careful - text nodes can change even if elements stay the same
-	"""
+    @dev be careful - text nodes can change even if elements stay the same
+    """
 
-	@staticmethod
-	def convert_dom_element_to_history_element(dom_element: DOMElementNode) -> DOMHistoryElement:
-		from browser_use.browser.context import BrowserContext
+    @staticmethod
+    def convert_dom_element_to_history_element(
+        dom_element: DOMElementNode,
+        input_text: Optional[str] = None,
+    ) -> DOMHistoryElement:
+        from browser_use.browser.context import BrowserContext
 
-		parent_branch_path = HistoryTreeProcessor._get_parent_branch_path(dom_element)
-		css_selector = BrowserContext._enhanced_css_selector_for_element(dom_element)
-		return DOMHistoryElement(
-			dom_element.tag_name,
-			dom_element.xpath,
-			dom_element.highlight_index,
-			parent_branch_path,
-			dom_element.attributes,
-			dom_element.shadow_root,
-			css_selector=css_selector,
-			page_coordinates=dom_element.page_coordinates,
-			viewport_coordinates=dom_element.viewport_coordinates,
-			viewport_info=dom_element.viewport_info,
-		)
+        parent_branch_path = HistoryTreeProcessor._get_parent_branch_path(dom_element)
+        css_selector = BrowserContext._enhanced_css_selector_for_element(dom_element)
+        return DOMHistoryElement(
+            dom_element.tag_name,
+            dom_element.xpath,
+            dom_element.highlight_index,
+            parent_branch_path,
+            dom_element.attributes,
+            dom_element.shadow_root,
+            css_selector=css_selector,
+            page_coordinates=dom_element.page_coordinates,
+            viewport_coordinates=dom_element.viewport_coordinates,
+            viewport_info=dom_element.viewport_info,
+            input_text=input_text,
+        )
 
-	@staticmethod
-	def find_history_element_in_tree(dom_history_element: DOMHistoryElement, tree: DOMElementNode) -> Optional[DOMElementNode]:
-		hashed_dom_history_element = HistoryTreeProcessor._hash_dom_history_element(dom_history_element)
+    @staticmethod
+    def find_history_element_in_tree(dom_history_element: DOMHistoryElement, tree: DOMElementNode) -> Optional[DOMElementNode]:
+        hashed_dom_history_element = HistoryTreeProcessor._hash_dom_history_element(dom_history_element)
 
-		def process_node(node: DOMElementNode):
-			if node.highlight_index is not None:
-				hashed_node = HistoryTreeProcessor._hash_dom_element(node)
-				if hashed_node == hashed_dom_history_element:
-					return node
-			for child in node.children:
-				if isinstance(child, DOMElementNode):
-					result = process_node(child)
-					if result is not None:
-						return result
-			return None
+        def process_node(node: DOMElementNode):
+            if node.highlight_index is not None:
+                hashed_node = HistoryTreeProcessor._hash_dom_element(node)
+                if hashed_node == hashed_dom_history_element:
+                    return node
+            for child in node.children:
+                if isinstance(child, DOMElementNode):
+                    result = process_node(child)
+                    if result is not None:
+                        return result
+            return None
 
-		return process_node(tree)
+        return process_node(tree)
 
-	@staticmethod
-	def compare_history_element_and_dom_element(dom_history_element: DOMHistoryElement, dom_element: DOMElementNode) -> bool:
-		hashed_dom_history_element = HistoryTreeProcessor._hash_dom_history_element(dom_history_element)
-		hashed_dom_element = HistoryTreeProcessor._hash_dom_element(dom_element)
+    @staticmethod
+    def compare_history_element_and_dom_element(dom_history_element: DOMHistoryElement, dom_element: DOMElementNode) -> bool:
+        hashed_dom_history_element = HistoryTreeProcessor._hash_dom_history_element(dom_history_element)
+        hashed_dom_element = HistoryTreeProcessor._hash_dom_element(dom_element)
 
-		return hashed_dom_history_element == hashed_dom_element
+        return hashed_dom_history_element == hashed_dom_element
 
-	@staticmethod
-	def _hash_dom_history_element(dom_history_element: DOMHistoryElement) -> HashedDomElement:
-		branch_path_hash = HistoryTreeProcessor._parent_branch_path_hash(dom_history_element.entire_parent_branch_path)
-		attributes_hash = HistoryTreeProcessor._attributes_hash(dom_history_element.attributes)
-		xpath_hash = HistoryTreeProcessor._xpath_hash(dom_history_element.xpath)
+    @staticmethod
+    def _hash_dom_history_element(dom_history_element: DOMHistoryElement) -> HashedDomElement:
+        branch_path_hash = HistoryTreeProcessor._parent_branch_path_hash(dom_history_element.entire_parent_branch_path)
+        attributes_hash = HistoryTreeProcessor._attributes_hash(dom_history_element.attributes)
+        xpath_hash = HistoryTreeProcessor._xpath_hash(dom_history_element.xpath)
 
-		return HashedDomElement(branch_path_hash, attributes_hash, xpath_hash)
+        return HashedDomElement(branch_path_hash, attributes_hash, xpath_hash)
 
-	@staticmethod
-	def _hash_dom_element(dom_element: DOMElementNode) -> HashedDomElement:
-		parent_branch_path = HistoryTreeProcessor._get_parent_branch_path(dom_element)
-		branch_path_hash = HistoryTreeProcessor._parent_branch_path_hash(parent_branch_path)
-		attributes_hash = HistoryTreeProcessor._attributes_hash(dom_element.attributes)
-		xpath_hash = HistoryTreeProcessor._xpath_hash(dom_element.xpath)
-		# text_hash = DomTreeProcessor._text_hash(dom_element)
+    @staticmethod
+    def _hash_dom_element(dom_element: DOMElementNode) -> HashedDomElement:
+        parent_branch_path = HistoryTreeProcessor._get_parent_branch_path(dom_element)
+        branch_path_hash = HistoryTreeProcessor._parent_branch_path_hash(parent_branch_path)
+        attributes_hash = HistoryTreeProcessor._attributes_hash(dom_element.attributes)
+        xpath_hash = HistoryTreeProcessor._xpath_hash(dom_element.xpath)
+        # text_hash = DomTreeProcessor._text_hash(dom_element)
 
-		return HashedDomElement(branch_path_hash, attributes_hash, xpath_hash)
+        return HashedDomElement(branch_path_hash, attributes_hash, xpath_hash)
 
-	@staticmethod
-	def _get_parent_branch_path(dom_element: DOMElementNode) -> list[str]:
-		parents: list[DOMElementNode] = []
-		current_element: DOMElementNode = dom_element
-		while current_element.parent is not None:
-			parents.append(current_element)
-			current_element = current_element.parent
+    @staticmethod
+    def _get_parent_branch_path(dom_element: DOMElementNode) -> list[str]:
+        parents: list[DOMElementNode] = []
+        current_element: DOMElementNode = dom_element
+        while current_element.parent is not None:
+            parents.append(current_element)
+            current_element = current_element.parent
 
-		parents.reverse()
+        parents.reverse()
 
-		return [parent.tag_name for parent in parents]
+        return [parent.tag_name for parent in parents]
 
-	@staticmethod
-	def _parent_branch_path_hash(parent_branch_path: list[str]) -> str:
-		parent_branch_path_string = '/'.join(parent_branch_path)
-		return hashlib.sha256(parent_branch_path_string.encode()).hexdigest()
+    @staticmethod
+    def _parent_branch_path_hash(parent_branch_path: list[str]) -> str:
+        parent_branch_path_string = '/'.join(parent_branch_path)
+        return hashlib.sha256(parent_branch_path_string.encode()).hexdigest()
 
-	@staticmethod
-	def _attributes_hash(attributes: dict[str, str]) -> str:
-		attributes_string = ''.join(f'{key}={value}' for key, value in attributes.items())
-		return hashlib.sha256(attributes_string.encode()).hexdigest()
+    @staticmethod
+    def _attributes_hash(attributes: dict[str, str]) -> str:
+        attributes_string = ''.join(f'{key}={value}' for key, value in attributes.items())
+        return hashlib.sha256(attributes_string.encode()).hexdigest()
 
-	@staticmethod
-	def _xpath_hash(xpath: str) -> str:
-		return hashlib.sha256(xpath.encode()).hexdigest()
+    @staticmethod
+    def _xpath_hash(xpath: str) -> str:
+        return hashlib.sha256(xpath.encode()).hexdigest()
 
-	@staticmethod
-	def _text_hash(dom_element: DOMElementNode) -> str:
-		""" """
-		text_string = dom_element.get_all_text_till_next_clickable_element()
-		return hashlib.sha256(text_string.encode()).hexdigest()
+    @staticmethod
+    def _text_hash(dom_element: DOMElementNode) -> str:
+        """ """
+        text_string = dom_element.get_all_text_till_next_clickable_element()
+        return hashlib.sha256(text_string.encode()).hexdigest()

--- a/browser_use/dom/history_tree_processor/view.py
+++ b/browser_use/dom/history_tree_processor/view.py
@@ -6,65 +6,69 @@ from pydantic import BaseModel
 
 @dataclass
 class HashedDomElement:
-	"""
-	Hash of the dom element to be used as a unique identifier
-	"""
+    """
+    Hash of the dom element to be used as a unique identifier
+    """
 
-	branch_path_hash: str
-	attributes_hash: str
-	xpath_hash: str
-	# text_hash: str
+    branch_path_hash: str
+    attributes_hash: str
+    xpath_hash: str
+    # text_hash: str
 
 
 class Coordinates(BaseModel):
-	x: int
-	y: int
+    x: int
+    y: int
 
 
 class CoordinateSet(BaseModel):
-	top_left: Coordinates
-	top_right: Coordinates
-	bottom_left: Coordinates
-	bottom_right: Coordinates
-	center: Coordinates
-	width: int
-	height: int
+    top_left: Coordinates
+    top_right: Coordinates
+    bottom_left: Coordinates
+    bottom_right: Coordinates
+    center: Coordinates
+    width: int
+    height: int
 
 
 class ViewportInfo(BaseModel):
-	scroll_x: int
-	scroll_y: int
-	width: int
-	height: int
+    scroll_x: int
+    scroll_y: int
+    width: int
+    height: int
 
 
 @dataclass
 class DOMHistoryElement:
-	tag_name: str
-	xpath: str
-	highlight_index: Optional[int]
-	entire_parent_branch_path: list[str]
-	attributes: dict[str, str]
-	shadow_root: bool = False
-	css_selector: Optional[str] = None
-	page_coordinates: Optional[CoordinateSet] = None
-	viewport_coordinates: Optional[CoordinateSet] = None
-	viewport_info: Optional[ViewportInfo] = None
+    tag_name: str
+    xpath: str
+    highlight_index: Optional[int]
+    entire_parent_branch_path: list[str]
+    attributes: dict[str, str]
+    shadow_root: bool = False
+    css_selector: Optional[str] = None
+    page_coordinates: Optional[CoordinateSet] = None
+    viewport_coordinates: Optional[CoordinateSet] = None
+    viewport_info: Optional[ViewportInfo] = None
+    input_text: Optional[str] = None
 
-	def to_dict(self) -> dict:
-		page_coordinates = self.page_coordinates.model_dump() if self.page_coordinates else None
-		viewport_coordinates = self.viewport_coordinates.model_dump() if self.viewport_coordinates else None
-		viewport_info = self.viewport_info.model_dump() if self.viewport_info else None
+    def to_dict(self) -> dict:
+        page_coordinates = self.page_coordinates.model_dump() if self.page_coordinates else None
+        viewport_coordinates = (
+            self.viewport_coordinates.model_dump() if self.viewport_coordinates else None
+        )
+        viewport_info = self.viewport_info.model_dump() if self.viewport_info else None
 
-		return {
-			'tag_name': self.tag_name,
-			'xpath': self.xpath,
-			'highlight_index': self.highlight_index,
-			'entire_parent_branch_path': self.entire_parent_branch_path,
-			'attributes': self.attributes,
-			'shadow_root': self.shadow_root,
-			'css_selector': self.css_selector,
-			'page_coordinates': page_coordinates,
-			'viewport_coordinates': viewport_coordinates,
-			'viewport_info': viewport_info,
-		}
+        return {
+            'tag_name': self.tag_name,
+            'xpath': self.xpath,
+            'highlight_index': self.highlight_index,
+            'entire_parent_branch_path': self.entire_parent_branch_path,
+            'attributes': self.attributes,
+            'shadow_root': self.shadow_root,
+            'css_selector': self.css_selector,
+            'page_coordinates': page_coordinates,
+            'viewport_coordinates': viewport_coordinates,
+            'viewport_info': viewport_info,
+            'input_text': self.input_text,
+        }

--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -146,6 +146,7 @@ history.action_names()      # Names of executed actions
 history.extracted_content() # Content extracted during execution
 history.errors()           # Any errors that occurred
 history.model_actions()     # All actions with their parameters
+# Input actions also include the typed text via `interacted_element['input_text']`
 ```
 
 The `AgentHistoryList` provides many helper methods to analyze the execution:


### PR DESCRIPTION
## Summary
- store typed text on DOMHistoryElement and convert DOM element to history with optional text
- capture typed text when collecting interacted elements
- update AgentHistoryList tests
- document how model_actions exposes typed input

## Testing
- `python -m py_compile browser_use/dom/history_tree_processor/service.py`
- `python -m py_compile browser_use/agent/views.py`
- `python -m py_compile browser_use/agent/tests.py`
- `pytest browser_use/agent/tests.py::test_model_actions_include_input_text -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6840c356ef188325a3e6f5ec998988ef