### PR TITLE
Fix interacted element detection after actions

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -434,13 +434,17 @@ class Agent(Generic[Context]):
 				return
 
 			if state:
-				metadata = StepMetadata(
-					step_number=self.state.n_steps,
-					step_start_time=step_start_time,
-					step_end_time=step_end_time,
-					input_tokens=tokens,
-				)
-				self._make_history_item(model_output, state, result, metadata)
+			metadata = StepMetadata(
+			step_number=self.state.n_steps,
+			step_start_time=step_start_time,
+			step_end_time=step_end_time,
+			input_tokens=tokens,
+			)
+			try:
+			state_after_actions = await self.browser_context.get_state()
+			except Exception:
+			state_after_actions = state
+			self._make_history_item(model_output, state_after_actions, result, metadata)
 
 	@time_execution_async('--handle_step_error (agent)')
 	async def _handle_step_error(self, error: Exception) -> list[ActionResult]:

--- a/browser_use/agent/tests.py
+++ b/browser_use/agent/tests.py
@@ -10,11 +10,12 @@ from browser_use.agent.views import (
 from browser_use.browser.views import BrowserState, BrowserStateHistory, TabInfo
 from browser_use.controller.registry.service import Registry
 from browser_use.controller.views import (
-        ClickElementAction,
-        DoneAction,
-        ExtractPageContentAction,
-        InputTextAction,
+    ClickElementAction,
+    DoneAction,
+    ExtractPageContentAction,
+    InputTextAction,
 )
+from browser_use.dom.history_tree_processor.view import DOMHistoryElement
 from browser_use.dom.views import DOMElementNode
 
 
@@ -141,7 +142,6 @@ def sample_history(action_registry):
 
 def test_last_model_output(sample_history: AgentHistoryList):
     last_output = sample_history.last_action()
-    print(last_output)
     assert last_output == {'done': {'text': 'Task completed'}}
 
 
@@ -156,7 +156,7 @@ def test_final_result(sample_history: AgentHistoryList):
 
 
 def test_is_done(sample_history: AgentHistoryList):
-    assert sample_history.is_done() == True
+    assert sample_history.is_done()
 
 
 def test_urls(sample_history: AgentHistoryList):
@@ -173,7 +173,6 @@ def test_all_screenshots(sample_history: AgentHistoryList):
 
 def test_all_model_outputs(sample_history: AgentHistoryList):
     outputs = sample_history.model_actions()
-    print(f'DEBUG: {outputs[0]}')
     assert len(outputs) == 3
     # get first key value pair
     assert dict([next(iter(outputs[0].items()))]) == {'click_element': {'index': 1}}
@@ -191,7 +190,7 @@ def test_empty_history():
     empty_history = AgentHistoryList(history=[])
     assert empty_history.last_action() is None
     assert empty_history.final_result() is None
-    assert empty_history.is_done() == False
+    assert not empty_history.is_done()
     assert len(empty_history.urls()) == 0
 
 


### PR DESCRIPTION
## Summary
- record browser state after executing actions so interacted elements are resolved correctly

## Testing
- `ruff check browser_use/agent/service.py` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_6841563494e083258ade3ddc07f96d35